### PR TITLE
fixed bug caused by renaming funcs

### DIFF
--- a/go.go
+++ b/go.go
@@ -99,14 +99,26 @@ func Go(a, b []byte) (changes []*Change, err error) {
 			ds := x.diffstat(ai, bi)
 			changes = append(changes, &Change{Name: s, DelLines: ds.del, InsLines: ds.ins})
 		} else {
-			ds := x.diffstat(bi, bi)
-			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: ds.ins})
+			var ln int
+			if len(ins) == len(del) {
+				ds := x.diffstat(bi, bi)
+				ln = ds.ins
+			} else {
+				ln = len(bytes.Split(x.bBytes(bi), newline))
+			}
+			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: ln})
 		}
 	}
 	for s, ai := range del {
 		if _, ok := ins[s]; !ok {
-			ds := x.diffstat(ai, ai)
-			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: ds.del})
+			var ln int
+			if len(ins) == len(del) {
+				ds := x.diffstat(ai, ai)
+				ln = ds.del
+			} else {
+				ln = len(bytes.Split(x.aBytes(ai), newline))
+			}
+			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: ln})
 		}
 	}
 

--- a/go.go
+++ b/go.go
@@ -99,12 +99,22 @@ func Go(a, b []byte) (changes []*Change, err error) {
 			ds := x.diffstat(ai, bi)
 			changes = append(changes, &Change{Name: s, DelLines: ds.del, InsLines: ds.ins})
 		} else {
-			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: len(bytes.Split(x.bBytes(bi), newline))})
+			spl := bytes.Split(x.bBytes(bi), newline)
+			lens := len(spl)
+			if string(spl[lens-1]) == "}" {
+				lens -= 1
+			}
+			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: lens})
 		}
 	}
 	for s, ai := range del {
 		if _, ok := ins[s]; !ok {
-			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: len(bytes.Split(x.aBytes(ai), newline))})
+			spl := bytes.Split(x.aBytes(ai), newline)
+			lens := len(spl)
+			if string(spl[lens-1]) == "}" {
+				lens -= 1
+			}
+			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: lens})
 		}
 	}
 

--- a/go.go
+++ b/go.go
@@ -99,22 +99,14 @@ func Go(a, b []byte) (changes []*Change, err error) {
 			ds := x.diffstat(ai, bi)
 			changes = append(changes, &Change{Name: s, DelLines: ds.del, InsLines: ds.ins})
 		} else {
-			spl := bytes.Split(x.bBytes(bi), newline)
-			lens := len(spl)
-			if string(spl[lens-1]) == "}" {
-				lens -= 1
-			}
-			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: lens})
+			ds := x.diffstat(bi, bi)
+			changes = append(changes, &Change{Name: s, Inserted: true, InsLines: ds.ins})
 		}
 	}
 	for s, ai := range del {
 		if _, ok := ins[s]; !ok {
-			spl := bytes.Split(x.aBytes(ai), newline)
-			lens := len(spl)
-			if string(spl[lens-1]) == "}" {
-				lens -= 1
-			}
-			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: lens})
+			ds := x.diffstat(ai, ai)
+			changes = append(changes, &Change{Name: s, Deleted: true, DelLines: ds.del})
 		}
 	}
 
@@ -130,11 +122,8 @@ func Go(a, b []byte) (changes []*Change, err error) {
 			ins -= c.InsLines
 			del -= c.DelLines
 		}
-		if ins < 0 {
-			ins = 0
-		}
-		if del < 0 {
-			del = 0
+		if ins < 0 || del < 0 {
+			panic(-1)
 		}
 		other.InsLines = ins
 		other.DelLines = del


### PR DESCRIPTION
Renaming functions is causing to subtract too many changes from "other" changes.
Replicate bug:

file A
```
package main
func main() {
}
func aaaa() {
}
func bbbb() {
}
```
file B
```
package main
//comment
//comment
func main() {
        return
}
func xxxx() {
        return
}
func cccc() {
        return
}
```
output:
```
func aaaa | 2 -- (deleted)
func bbbb | 2 -- (deleted)
func cccc | 3 +++ (inserted)
func main | 1 +
func xxxx | 3 +++ (inserted)
other     | 0
```
bugfix output:
```
func aaaa | 1 - (deleted)
func bbbb | 1 - (deleted)
func cccc | 2 ++ (inserted)
func main | 1 +
func xxxx | 2 ++ (inserted)
other     | 2 ++
```

